### PR TITLE
Test against PHP 8.5 and Laravel 12/13; drop EOL versions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,16 +17,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [11.*, 10.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.63
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
+          - laravel: 13.*
+            testbench: 11.*
+          - laravel: 12.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -48,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,21 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": ">=10.0"
+        "illuminate/contracts": ">=12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "nunomaduro/collision": "^8.8",
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,5 +6,7 @@ parameters:
     paths:
         - src
     tmpDir: build/phpstan
-    checkOctaneCompatibility: true
-    checkModelProperties: true
+    ignoreErrors:
+        # The package's traits are part of its public API and are consumed by
+        # the host application, so they are never used within src/ itself.
+        - identifier: trait.unused


### PR DESCRIPTION
Modernizes the CI matrix to PHP 8.3/8.4/8.5 x Laravel 12/13 (Testbench 11/10), dropping the now-EOL Laravel 10/11 and PHP 8.2, and bumps dev deps to match (Pest 4, Larastan 3, PHPStan-rules 2, collision 8.8). Raises the package floor to php ^8.3 and illuminate/contracts >=12.0, sets the PHPStan workflow to PHP 8.4, and swaps the PHPStan-2-removed checkOctaneCompatibility/checkModelProperties params for an ignoreErrors on the new trait.unused rule (these public-API traits are not used within src/). All four Laravel x stability combos were verified locally to install, pass Pest, and pass PHPStan on PHP 8.5. Heads-up: dropping PHP 8.2 and Laravel 10/11 is a breaking support change and should ship as a major version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)